### PR TITLE
v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.3.1
+- Fix issue with Shove moving layer when text is in edit mode.
+
 ## 1.3.0
 - Add ability to change Shove hotkey.
 

--- a/NudgePushShove.sketchplugin/Contents/Sketch/manifest.json
+++ b/NudgePushShove.sketchplugin/Contents/Sketch/manifest.json
@@ -1,7 +1,7 @@
 {
   "name" : "Nudge, Push, Shove",
   "description" : "Change the big and small nudge settings for Sketch. Plus, get access to an even bigger nudge setting.",
-  "version" : "1.3.0",
+  "version" : "1.3.1",
   "identifier" : "com.mfouquet.sketch.nudgepushshove",
   "author" : "Michael Fouquet",
   "authorEmail" : "michael.fouquet@me.com",

--- a/NudgePushShove.sketchplugin/Contents/Sketch/runShove.js
+++ b/NudgePushShove.sketchplugin/Contents/Sketch/runShove.js
@@ -29,6 +29,10 @@ function shoveObjects(context, direction) {
   selection.iterate(function(layer) {
     sketchLayer = layer.sketchObject;
 
+    if (sketchLayer.class() == "MSTextLayer" && sketchLayer.isEditingText()) {
+      return;
+    }
+
     if (direction === 'up') {
       sketchLayer.frame().setY(parseFloat(sketchLayer.frame().y()) - parseFloat(shoveAmount));
     } else if (direction === 'right') {

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,6 +6,18 @@
     <description>Easily customize the small and big nudge settings right within Sketch and get access to an even bigger nudge setting to boot.</description>
     <language>en</language>
       <item>
+        <title>Version 1.3.1</title>
+        <description>
+          <![CDATA[
+            <ul>
+              <li>Fix issue with Shove moving layer when text is in edit mode.</li>
+            </ul>
+          ]]>
+        </description>
+        <pubDate>Mon, 28 Aug 2017 12:58:00 +0000</pubDate>
+        <enclosure url="https://github.com/mfouquet/NudgePushShove/archive/v1.3.1.zip" sparkle:version="1.3.1" type="application/octet-stream" />
+      </item>
+      <item>
         <title>Version 1.3.0</title>
         <description>
           <![CDATA[


### PR DESCRIPTION
This fixes an issue where the Shove command would work even if the user was editing text (thus moving the layer when you were trying to select some text).