### PR TITLE
Update ui.css

### DIFF
--- a/src/web/ui.css
+++ b/src/web/ui.css
@@ -18,7 +18,7 @@ body {
   position: absolute;
   top: 4px;
   transition: color 0.15s ease-in-out;
-  right: 8px;
+  left: 8px;
 }
 
 .dismiss:focus,


### PR DESCRIPTION
Because Sketch is only available for macOS–the GUI of this plugin should follow the macOS look and feel.
Therefore, the close icon should be placed on the lefthand side of the plugin window.

Changing the direction property from right to left in line 21 should ensure a better UX and consistency.